### PR TITLE
Add Packer configuration for GCP image building

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,40 @@
+# Justfile for dotfiles automation
+
+# Build GCP image with Packer
+packer-build project_id="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z "{{project_id}}" ]; then
+        if [ -z "${GCP_PROJECT_ID:-}" ]; then
+            echo "Error: GCP project ID not provided"
+            echo "Usage: just packer-build <project-id>"
+            echo "   or: export GCP_PROJECT_ID=<project-id> && just packer-build"
+            exit 1
+        fi
+        echo "Using GCP_PROJECT_ID from environment: ${GCP_PROJECT_ID}"
+        packer build image.pkr.hcl
+    else
+        echo "Building image for project: {{project_id}}"
+        packer build -var="project_id={{project_id}}" image.pkr.hcl
+    fi
+
+# Validate Packer configuration
+packer-validate:
+    packer validate image.pkr.hcl
+
+# Format Packer configuration
+packer-fmt:
+    packer fmt image.pkr.hcl
+
+# Initialize Packer (install required plugins)
+packer-init:
+    packer init image.pkr.hcl
+
+# Show Packer configuration details
+packer-inspect:
+    packer inspect image.pkr.hcl
+
+# List available Just commands
+help:
+    @just --list

--- a/PACKER.md
+++ b/PACKER.md
@@ -1,0 +1,141 @@
+# Building GCP Images with Packer
+
+This directory contains a Packer configuration to build Google Cloud Platform images with your dotfiles pre-configured.
+
+## Prerequisites
+
+1. **Install Packer**: https://www.packer.io/downloads
+2. **Install Just**: Already included in `install.sh`
+3. **GCP Authentication**: Authenticate with Google Cloud
+   ```bash
+   gcloud auth application-default login
+   ```
+4. **GCP Project**: Have a GCP project ID ready
+
+## Quick Start
+
+1. **Initialize Packer** (first time only):
+   ```bash
+   just packer-init
+   ```
+
+2. **Validate configuration**:
+   ```bash
+   just packer-validate
+   ```
+
+3. **Build the image**:
+   ```bash
+   # Option 1: Pass project ID directly
+   just packer-build YOUR_GCP_PROJECT_ID
+
+   # Option 2: Use environment variable
+   export GCP_PROJECT_ID=YOUR_GCP_PROJECT_ID
+   just packer-build
+   ```
+
+## Configuration
+
+You can customize the build by setting variables:
+
+```bash
+packer build \
+  -var="project_id=my-project" \
+  -var="zone=us-west1-a" \
+  -var="machine_type=n1-standard-4" \
+  -var="disk_size=30" \
+  image.pkr.hcl
+```
+
+### Available Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `project_id` | `$GCP_PROJECT_ID` | GCP project ID |
+| `zone` | `us-central1-a` | GCP zone for build VM |
+| `source_image_family` | `ubuntu-2404-lts-amd64` | Base image family |
+| `image_name` | `dotfiles-dev-{{timestamp}}` | Output image name |
+| `image_family` | `dotfiles-dev` | Image family |
+| `machine_type` | `n1-standard-2` | Build VM machine type |
+| `disk_size` | `20` | Disk size in GB |
+| `ssh_username` | `packer` | SSH username |
+
+## Using the Image
+
+Once built, create a new VM instance from the image:
+
+```bash
+gcloud compute instances create dev-vm \
+  --project=YOUR_PROJECT_ID \
+  --zone=us-central1-a \
+  --machine-type=n1-standard-4 \
+  --image-family=dotfiles-dev \
+  --boot-disk-size=50GB \
+  --boot-disk-type=pd-ssd
+```
+
+Or use the latest image directly:
+
+```bash
+# Get the latest image name
+IMAGE=$(gcloud compute images list \
+  --filter="family:dotfiles-dev" \
+  --sort-by=~creationTimestamp \
+  --limit=1 \
+  --format="value(name)")
+
+# Create instance
+gcloud compute instances create dev-vm \
+  --image=$IMAGE \
+  --machine-type=n1-standard-4
+```
+
+## What Gets Installed
+
+The image includes everything from `install.sh`:
+- Development tools: Go, Node.js, Rust
+- CLI utilities: eza, bat, zoxide, fzf, ripgrep, fd, delta, difftastic
+- Editors: Neovim (with AstroNvim v5 plugins pre-installed)
+- Version control: Git, Tig, Jujutsu
+- Infrastructure: Docker, gcloud, awscli
+- AI tools: Claude Code, Gemini CLI
+- And more: tmux, direnv, jq, gh, gnupg, keepassxc, bitwarden-cli
+
+All dotfiles are symlinked to the home directory via `setup.sh`.
+
+## Updating the Image
+
+To update the image with new dotfiles changes:
+
+1. Commit and push your dotfiles changes
+2. Run the build again with `just packer-build`
+3. A new image will be created with the timestamp in the name
+4. The image family `dotfiles-dev` will point to the latest image
+
+## Troubleshooting
+
+**Build fails during install.sh**:
+- Increase the timeout in the provisioner section
+- Check the Packer build logs for specific package failures
+
+**Authentication errors**:
+- Run `gcloud auth application-default login`
+- Verify your GCP project ID is correct
+
+**Neovim plugin installation issues**:
+- The build allows plugin installation to fail gracefully
+- Plugins will auto-install on first manual Neovim launch if needed
+
+**SSH connection issues**:
+- Check your VPC firewall rules allow SSH (port 22)
+- Verify the build VM can access the internet
+
+## Cost Optimization
+
+- The build VM runs for approximately 20-30 minutes
+- Using `n1-standard-2` minimizes cost while maintaining reasonable build speed
+- Images are stored as GCP Custom Images (charged per GB per month)
+- Consider deleting old images to reduce storage costs:
+  ```bash
+  gcloud compute images delete OLD_IMAGE_NAME
+  ```

--- a/image.pkr.hcl
+++ b/image.pkr.hcl
@@ -1,0 +1,149 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.1.1"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+  }
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+  default     = env("GCP_PROJECT_ID")
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone for the build VM"
+  default     = "us-central1-a"
+}
+
+variable "source_image_family" {
+  type        = string
+  description = "Source image family to use as base"
+  default     = "ubuntu-2404-lts-amd64"
+}
+
+variable "image_name" {
+  type        = string
+  description = "Name of the output image"
+  default     = "dotfiles-dev-{{timestamp}}"
+}
+
+variable "image_family" {
+  type        = string
+  description = "Image family for the output image"
+  default     = "dotfiles-dev"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the build VM"
+  default     = "n1-standard-2"
+}
+
+variable "disk_size" {
+  type        = number
+  description = "Disk size in GB"
+  default     = 20
+}
+
+variable "ssh_username" {
+  type        = string
+  description = "SSH username for connecting to the build VM"
+  default     = "packer"
+}
+
+source "googlecompute" "dotfiles" {
+  project_id          = var.project_id
+  zone                = var.zone
+  source_image_family = var.source_image_family
+  image_name          = var.image_name
+  image_family        = var.image_family
+  machine_type        = var.machine_type
+  disk_size           = var.disk_size
+  ssh_username        = var.ssh_username
+
+  image_description   = "Development environment with dotfiles pre-configured"
+
+  # Add labels for organization
+  image_labels = {
+    environment = "development"
+    managed_by  = "packer"
+    created     = "{{timestamp}}"
+  }
+}
+
+build {
+  sources = ["source.googlecompute.dotfiles"]
+
+  # Update system packages
+  provisioner "shell" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get upgrade -y",
+      "sudo apt-get install -y git curl wget build-essential"
+    ]
+  }
+
+  # Clone dotfiles repo
+  provisioner "shell" {
+    inline = [
+      "git clone https://github.com/tynes/dotfiles.git ~/dotfiles"
+    ]
+  }
+
+  # Run install script to install all dependencies
+  provisioner "shell" {
+    inline = [
+      "cd ~/dotfiles",
+      "chmod +x install.sh",
+      "./install.sh"
+    ]
+    # Increase timeout since this installs many packages
+    timeout = "30m"
+  }
+
+  # Run setup script to create symlinks
+  provisioner "shell" {
+    inline = [
+      "cd ~/dotfiles",
+      "chmod +x setup.sh",
+      "./setup.sh"
+    ]
+  }
+
+  # Re-run install script to initialize Neovim plugins now that config is symlinked
+  provisioner "shell" {
+    inline = [
+      "cd ~/dotfiles",
+      "./install.sh"
+    ]
+    # Allow this to fail gracefully if there are issues with plugin installation
+    valid_exit_codes = [0, 1]
+  }
+
+  # Clean up
+  provisioner "shell" {
+    inline = [
+      "# Clean package manager cache",
+      "sudo apt-get clean",
+      "sudo apt-get autoremove -y",
+
+      "# Clear bash history for security",
+      "history -c",
+      "rm -f ~/.bash_history",
+
+      "# Clear any temporary files",
+      "sudo rm -rf /tmp/*",
+      "sudo rm -rf /var/tmp/*"
+    ]
+  }
+
+  # Display completion message
+  post-processor "manifest" {
+    output = "packer-manifest.json"
+    strip_path = true
+  }
+}


### PR DESCRIPTION
## Summary
- Added Packer configuration to build GCP images with dotfiles pre-configured
- Created Justfile with automation commands for building, validating, and managing Packer images
- Added comprehensive documentation in PACKER.md with setup instructions and usage examples

## Test plan
- [ ] Run `just packer-init` to initialize Packer plugins
- [ ] Run `just packer-validate` to verify configuration is valid
- [ ] Run `just packer-build <project-id>` to build a test image in GCP
- [ ] Verify the built image includes all dotfiles and tools from install.sh
- [ ] Create a VM instance from the image and verify everything works

🤖 Generated with [Claude Code](https://claude.com/claude-code)